### PR TITLE
Update AndroidX Core and Android requirements

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:icon="@drawable/icon"
         {{/has-icons?}}
         android:label="{{project.title}}" android:hasCode="true"
-        android:name="android.support.multidex.MultiDexApplication"
+        android:name="android.app.Application"
         android:enableOnBackInvokedCallback="true"
         android:debuggable="{{android.debuggable}}">
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 # extension-permissions
 Defold [native extension](https://www.defold.com/manuals/extensions/) to query for and request application permissions from the user or operating system on Android devices.
 
+Android API level 23 or newer is required.
+
 [Manual, API and setup instructions](https://www.defold.com/extension-permissions/) is available on the official Defold site.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ brief: Extension to query for and request application permissions from the user 
 
 This extension provides functions to query for and request application permissions from the user or operating system.
 At the moment it supports only Android.
+Android API level 23 or newer is required.
 
 
 ## Installation

--- a/extension-permissions/manifests/android/build.gradle
+++ b/extension-permissions/manifests/android/build.gradle
@@ -1,7 +1,8 @@
 repositories {
+    google()
     mavenCentral()
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.2.0'
+    implementation 'androidx.core:core:1.19.0'
 }

--- a/game.project
+++ b/game.project
@@ -17,4 +17,4 @@ include_dirs = extension-permissions
 [android]
 package = com.defold.permissions
 manifest = /AndroidManifest.xml
-
+minimum_sdk_version = 23


### PR DESCRIPTION
## Summary

- update AndroidX Core to 1.19.0
- add Google Maven as an Android dependency repository
- raise the Android minimum API level to 23 to match the updated AndroidX requirements
- replace the legacy android.support.multidex.MultiDexApplication example application class with the platform android.app.Application

## Why

AndroidX Core 1.19.0 is the current stable release and now requires API 23. The example manifest still referenced the pre-AndroidX support-library multidex application class, although this extension does not require that legacy class. Using the platform application class keeps the example compatible with the updated dependency stack and avoids retaining an obsolete support-library reference.

This is a dependency and Android configuration update only; the extension's Lua and native permission APIs are unchanged.

## Compatibility notes

- Android now requires API level 23 or newer.
- Projects that override the extension's Android minimum SDK must use 23 or newer.
- No source migration is required for extension users beyond meeting the updated Android SDK floor.

## Validation

- Built the Android example successfully with /Users/agulev/Downloads/bob.jar against the production Defold Extender.
- Confirmed the updated native extension dependency graph resolves and compiles successfully.